### PR TITLE
Dev

### DIFF
--- a/bin/beaker_init
+++ b/bin/beaker_init
@@ -63,4 +63,4 @@ PUPPET_CMD=$(get_puppet_cmd)
 # just incase we need to install exra modules from the forge
 install_puppet_module "puppetlabs-stdlib"
 
-eval $PUPPET_CMD apply --basemodulepath "$MODULE_PATH/modules:../modules:$($PUPPET_CMD config print basemodulepath)" --hiera_config $HIERA_YAML $MODULE_PATH/site.pp
+eval $PUPPET_CMD apply --basemodulepath "$MODULE_PATH/modules:../modules:$($PUPPET_CMD config print basemodulepath)" --hiera_config $HIERA_YAML $MODULE_PATH/site.pp $*

--- a/bin/beaker_init
+++ b/bin/beaker_init
@@ -63,4 +63,4 @@ PUPPET_CMD=$(get_puppet_cmd)
 # just incase we need to install exra modules from the forge
 install_puppet_module "puppetlabs-stdlib"
 
-$PUPPET_CMD apply --modulepath ../:$MODULE_PATH/modules --hiera_config $HIERA_YAML $MODULE_PATH/site.pp
+eval $PUPPET_CMD apply --basemodulepath "$MODULE_PATH/modules:../modules:$($PUPPET_CMD config print basemodulepath)" --hiera_config $HIERA_YAML $MODULE_PATH/site.pp

--- a/files/tasks/acceptance.rb
+++ b/files/tasks/acceptance.rb
@@ -1,0 +1,13 @@
+require_relative "helpers"
+
+desc "Acceptance tests"
+namespace :acceptance do
+
+  task :tests do
+     set_provisioned_env(has_been_provisioned)
+     Rake::Task[:beaker].invoke
+
+     File.write($PROVISIONED_FILENAME, '')
+  end
+
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,10 @@ class beaker_init::params {
       'ensure'                     => 'present',
       'gem_attrs'                  => [':require => false'],
     },
+    'rspec-puppet-facts'           => {
+      'ensure'                     => 'present',
+      'gem_attrs'                  => [':require => false']
+    },
   }
 
 }


### PR DESCRIPTION
- Minor update to bin/beaker_init script to better handle module lookup.
- Added additional rake task for running beaker acceptance specs.  This allows you to run your acceptance tests only.
- Added `rspec-puppet-facts` to Gemfile as a default for better handling of supported operating systems.  Only requirement here is that your `metadata.json` file reflect the supported operating systems in your module.
