### PR TITLE
fixing spec_helper_acceptance.rb when module directory does not conta…

### DIFF
--- a/files/specs/spec_helper_acceptance.rb
+++ b/files/specs/spec_helper_acceptance.rb
@@ -15,7 +15,7 @@ end
 RSpec.configure do |c|
   # Project root
   module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  module_name = module_root.split('-').last
+  module_name = File.basename(module_root.split('-').last)
 
   # Readable test descriptions
   c.formatter = :documentation


### PR DESCRIPTION
This pull request addresses a minor issue when the spec_helper_accepetance.rb script tries to sync your module directory that does not contain a '-' in the module directory.  This pull request addresses both cases.
